### PR TITLE
move header image to nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     
     <body class="landing">
         <nav class="navbar"> <!-- navigation bar -->
+            <img src="assets/images/bloc_jams_logo.png" alt="bloc jams logo" class="logo">
         </nav> 
-        <img src="assets/images/bloc_jams_logo.png" alt="bloc jams logo" class="logo">
         <section class="hero-content "> <!-- hero Container -->
             <h1 class="hero-title">Turn the music up!</h1>
         </section> 


### PR DESCRIPTION
Take a look at this link and notice that there is a weird purple bar at the top of the page. 

Current: 
<img width="348" alt="screenshot 2016-08-29 22 03 13" src="https://cloud.githubusercontent.com/assets/5713670/18076614/672d22e6-6e34-11e6-8841-d35ba5e7e6df.png">

What it should be 
<img width="309" alt="screenshot 2016-08-29 22 03 47" src="https://cloud.githubusercontent.com/assets/5713670/18076629/89ee2690-6e34-11e6-8250-3826b6d71f1e.png">

Feel free to merge this in, but note my change adds the img to the Navbar
